### PR TITLE
Add app.json file to enable Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,37 @@
+{
+    "name": "govuk-public-asset-checker",
+    "repository": "https://github.com/alphagov/public-asset-checker",
+    "env": {
+      "GOVUK_APP_DOMAIN": {
+        "value": "www.gov.uk"
+      },
+      "GOVUK_WEBSITE_ROOT": {
+        "value": "https://www.gov.uk"
+      },
+      "PLEK_SERVICE_CONTENT_STORE_URI": {
+        "value": "https://www.gov.uk/api"
+      },
+      "PLEK_SERVICE_SEARCH_URI": {
+        "value": "https://www.gov.uk/api"
+      },
+      "PLEK_SERVICE_STATIC_URI": {
+        "value": "assets.digital.cabinet-office.gov.uk"
+      },
+      "RAILS_SERVE_STATIC_ASSETS": {
+        "value": "yes"
+      },
+      "SECRET_KEY_BASE": {
+        "generator": "secret"
+      },
+      "HEROKU_APP_NAME": {
+        "required": true
+      }
+    },
+    "image": "heroku/ruby",
+    "buildpacks": [
+      {
+        "url": "https://github.com/heroku/heroku-buildpack-ruby"
+      }
+    ],
+    "addons": []
+  }


### PR DESCRIPTION
We followed the instructions presented [here ](https://docs.publishing.service.gov.uk/manual/review-apps.html#enable-your-app-to-work-on-heroku) to set up reviewing this app via Heroku. We already have a procfile and gemfile set up to enable this, adding the app.json file is the final step required. 