### PR TITLE
Fix bundler issue for Heroku

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,11 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.14.0-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.0-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.14.0-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
     parser (3.2.0.0)
@@ -335,7 +339,9 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap
@@ -369,4 +375,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.3.23
+   2.3.7


### PR DESCRIPTION
Fix to an error we encountered while trying to deploy to Heroku. 

Running: BUNDLE_WITHOUT='development:test' BUNDLE_PATH=vendor/bundle BUNDLE_BIN=vendor/bundle/bin 

BUNDLE_DEPLOYMENT=1 bundle install -j4
         Your bundle only supports platforms ["x86_64-darwin-21"] but your local platform
         is x86_64-linux. Add the current platform to the lockfile with
         `bundle lock --add-platform x86_64-linux` and try again.
         Bundler Output: Your bundle only supports platforms ["x86_64-darwin-21"] but your local platform
         is x86_64-linux. Add the current platform to the lockfile with
         `bundle lock --add-platform x86_64-linux` and try again.