### PR TITLE
remove govuk config

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,21 +2,6 @@
     "name": "govuk-public-asset-checker",
     "repository": "https://github.com/alphagov/public-asset-checker",
     "env": {
-      "GOVUK_APP_DOMAIN": {
-        "value": "www.gov.uk"
-      },
-      "GOVUK_WEBSITE_ROOT": {
-        "value": "https://www.gov.uk"
-      },
-      "PLEK_SERVICE_CONTENT_STORE_URI": {
-        "value": "https://www.gov.uk/api"
-      },
-      "PLEK_SERVICE_SEARCH_URI": {
-        "value": "https://www.gov.uk/api"
-      },
-      "PLEK_SERVICE_STATIC_URI": {
-        "value": "assets.digital.cabinet-office.gov.uk"
-      },
       "RAILS_SERVE_STATIC_ASSETS": {
         "value": "yes"
       },


### PR DESCRIPTION
We suspect we are having some issues deploying the app to Heroku because of these variables. We don't think they are strictly required, given that this tool isn't going to be hosted on the gov.uk domain. 