### PR TITLE
Update version check and update view with current version or size 

### DIFF
--- a/app/models/asset_version_checker.rb
+++ b/app/models/asset_version_checker.rb
@@ -7,7 +7,7 @@ class AssetVersionChecker < AssetChecker
 
   def compare
     public_assets.all.find_each do |asset|
-      current = get_version(asset.url, /"v=(\d+)"/)
+      current = get_version(asset.url, /T="(\d+)"/)
       expected = get_version(ENV["GITHUB_URL"], /SCRIPT_VERSION = "(\d+)"/)
 
       category = "WARNING"

--- a/app/models/public_asset_status.rb
+++ b/app/models/public_asset_status.rb
@@ -4,4 +4,8 @@ class PublicAssetStatus < ApplicationRecord
   validates :public_asset_id, presence: true
   validates :size, presence: true, unless: :version
   validates :version, presence: true, unless: :size
+
+  def value
+    version || size
+  end
 end

--- a/app/views/public_assets/index.html.erb
+++ b/app/views/public_assets/index.html.erb
@@ -6,6 +6,7 @@
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header">URL</th>
+        <th scope="col" class="govuk-table__header">Current value</th>
         <th scope="col" class="govuk-table__header">Validate by</th>
         <th scope="col" class="govuk-table__header"></th>
       </tr>
@@ -15,6 +16,9 @@
         <tr class="govuk-table__row">
           <td scope="row" class="govuk-table__cell">
             <%= public_asset.url %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= public_asset.public_asset_statuses.last.value %>
           </td>
           <td class="govuk-table__cell">
             <%= public_asset.validate_by %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -37,7 +37,7 @@ if Rails.env.development?
     public_assets_by_version.all.each do |asset|
       PublicAssetStatus.create!(
         public_asset_id: asset.id,
-        version: "v=#{Faker::Number.number(digits: 3)}",
+        version: "T=\"#{Faker::Number.number(digits: 3)}\"",
         created_at: date_time,
         updated_at: date_time,
       )

--- a/spec/models/asset_version_checker_spec.rb
+++ b/spec/models/asset_version_checker_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe AssetVersionChecker, type: :model do
     end
 
     it "when the versions match, we get a SAME notification" do
-      stub_get(public_asset.url, '"v=42"')
+      stub_get(public_asset.url, 'T="42"')
       stub_get(ENV["GITHUB_URL"], 'SCRIPT_VERSION = "42"')
       stub_post(public_asset.url, "SAME", 42, 42)
 
@@ -30,7 +30,7 @@ RSpec.describe AssetVersionChecker, type: :model do
     end
 
     it "when the versions don't match, we get a WARNING notification" do
-      stub_get(public_asset.url, '"v=50"')
+      stub_get(public_asset.url, 'T="50"')
       stub_get(ENV["GITHUB_URL"], 'SCRIPT_VERSION = "42"')
       stub_post(public_asset.url, "WARNING", 50, 42)
 


### PR DESCRIPTION
This change does two things:

- Updates the `version` checker logic as the LUX JavaScript now uses `T="xxx"`.
- Adds the current `size` or `version` onto the UI so that it is easily visible. A simple method is added for convenience.
