### PR TITLE
Format size output in a more human friendly manner

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,11 @@
 module ApplicationHelper
+  include ActionView::Helpers::NumberHelper
+
+  def humanize_size(size)
+    if size < 1024
+      "#{number_with_delimiter(size, delimiter: ',')} Bytes"
+    else
+      "#{number_to_human_size(size)} (#{number_with_delimiter(size, delimiter: ',')} Bytes)"
+    end
+  end
 end

--- a/app/models/asset_size_checker.rb
+++ b/app/models/asset_size_checker.rb
@@ -1,6 +1,9 @@
 require "faraday"
+require Rails.root.join("app/helpers/application_helper")
 
 class AssetSizeChecker
+  include ApplicationHelper
+
   attr_reader :asset
 
   def initialize(asset)
@@ -14,12 +17,12 @@ class AssetSizeChecker
 
     notification = Notification.new(asset.id, asset.url)
     if expected == current
-      nothing_to_do(notification, current, expected)
+      nothing_to_do(notification, humanize_size(current), humanize_size(expected))
     elsif within_tolerance?(current, expected)
       PublicAssetStatus.create!(public_asset_id: asset.id, size: current)
-      automatic_update(notification, current, expected)
+      automatic_update(notification, humanize_size(current), humanize_size(expected))
     else
-      action_required(notification, current, expected)
+      action_required(notification, humanize_size(current), humanize_size(expected))
     end
   end
 
@@ -33,7 +36,7 @@ private
   def action_required(notification, current, expected)
     notification.title = "Action required"
     notification.color = "needs-attention"
-    notification.value = "Expected size is [#{expected}] Actual size is [#{current}]. Please check this script and update the <#{ENV['PRODUCTION_URL']}/public_assets/#{notification.id}|latest value> when you're happy that the situation is resolved."
+    notification.value = "Expected size is *#{expected}* Actual size is *#{current}*. Please check this script and update the <#{ENV['PRODUCTION_URL']}/public_assets/#{notification.id}|latest value> when you're happy that the situation is resolved."
 
     notification
   end
@@ -41,7 +44,7 @@ private
   def automatic_update(notification, current, expected)
     notification.title = "Automatic update"
     notification.color = "other"
-    notification.value = "Expected size was [#{expected}] Actual size is [#{current}]. The expected value has been automatically updated to the new actual size."
+    notification.value = "Expected size was *#{expected}* Actual size is *#{current}*. The expected value has been automatically updated to the new actual size."
 
     notification
   end
@@ -49,7 +52,7 @@ private
   def nothing_to_do(notification, current, expected)
     notification.title = "Nothing to do"
     notification.color = "same"
-    notification.value = "Expected size is [#{expected}] Actual size is [#{current}]."
+    notification.value = "Expected size is *#{expected}* Actual size is *#{current}*."
 
     notification
   end

--- a/app/models/asset_version_checker.rb
+++ b/app/models/asset_version_checker.rb
@@ -30,7 +30,7 @@ private
   def action_required(notification, current, expected)
     notification.title = "Action required"
     notification.color = "needs-attention"
-    notification.value = "<#{ENV['GITHUB_URL']}|Source version> is [#{expected}] <#{notification.url}|Our version> is [#{current}]. Please fix our version then update the <#{ENV['PRODUCTION_URL']}/public_assets/#{notification.id}|latest value>."
+    notification.value = "<#{ENV['GITHUB_URL']}|Source version> is *#{expected}* <#{notification.url}|Our version> is *#{current}*. Please fix our version then update the <#{ENV['PRODUCTION_URL']}/public_assets/#{notification.id}|latest value>."
 
     notification
   end
@@ -38,7 +38,7 @@ private
   def nothing_to_do(notification, current, expected)
     notification.title = "Nothing to do"
     notification.color = "same"
-    notification.value = "<#{ENV['GITHUB_URL']}|Source version> is [#{expected}] <#{notification.url}|Our version> is [#{current}]."
+    notification.value = "<#{ENV['GITHUB_URL']}|Source version> is *#{expected}* <#{notification.url}|Our version> is *#{current}*."
 
     notification
   end

--- a/app/views/public_asset_statuses/_form.html.erb
+++ b/app/views/public_asset_statuses/_form.html.erb
@@ -10,6 +10,9 @@
     </div>
   <% else %>
     <div class="govuk-form-group">
+      <div id="size-hint" class="govuk-hint">
+        Please give new size in Bytes without commas.
+      </div>
       <%= form.number_field :size, value: current_value, class: "govuk-input" %>
     </div>
   <% end %>

--- a/app/views/public_assets/index.html.erb
+++ b/app/views/public_assets/index.html.erb
@@ -18,7 +18,14 @@
             <%= public_asset.url %>
           </td>
           <td class="govuk-table__cell">
-            <%= public_asset.public_asset_statuses.last.value if public_asset.public_asset_statuses.any? %>
+            <% if public_asset.public_asset_statuses.any? %>
+              <% current_value = public_asset.public_asset_statuses.last.value %>
+              <% if public_asset.validate_by_size? %>
+                <%= humanize_size(current_value) %>
+              <% else %>
+                <%= current_value %>
+              <% end %>
+            <% end %>
           </td>
           <td class="govuk-table__cell">
             <%= public_asset.validate_by %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe ApplicationHelper, type: :helper do
+  describe "humanize_size" do
+    it "returns 0 Bytes when 0" do
+      expect(humanize_size(0)).to eq "0 Bytes"
+    end
+
+    it "returns only the size in Bytes when lower then a KB" do
+      expect(humanize_size(1023)).to eq "1,023 Bytes"
+    end
+
+    it "returns 1 KB when bytes is 1024" do
+      expect(humanize_size(1024)).to eq "1 KB (1,024 Bytes)"
+    end
+
+    it "returns 1.21 KB when bytes is 1234" do
+      expect(humanize_size(1234)).to eq "1.21 KB (1,234 Bytes)"
+    end
+
+    it "returns 12.1 KB when bytes is 12345" do
+      expect(humanize_size(12_345)).to eq "12.1 KB (12,345 Bytes)"
+    end
+
+    it "returns 1.18 MB when bytes is 1234567" do
+      expect(humanize_size(1_234_567)).to eq "1.18 MB (1,234,567 Bytes)"
+    end
+
+    it "returns 1.15 GB when bytes is 1234567890" do
+      expect(humanize_size(1_234_567_890)).to eq "1.15 GB (1,234,567,890 Bytes)"
+    end
+
+    it "returns 1.12 TB when bytes is 1234567890123" do
+      expect(humanize_size(1_234_567_890_123)).to eq "1.12 TB (1,234,567,890,123 Bytes)"
+    end
+
+    it "returns 1.1 PB when bytes is 1234567890123456" do
+      expect(humanize_size(1_234_567_890_123_456)).to eq "1.1 PB (1,234,567,890,123,456 Bytes)"
+    end
+  end
+end


### PR DESCRIPTION
The output format for size values used to be structured as a simple integer (in bytes).

This change improves on that format and makes the number easier to read and understand.

| Before | After |
|---|---|
| ![Screenshot 2023-05-22 at 11 57 54](https://github.com/alphagov/public-asset-checker/assets/44037625/e0e64f4a-7738-444e-a49e-022a839873c0) | ![Screenshot 2023-05-22 at 11 58 29](https://github.com/alphagov/public-asset-checker/assets/44037625/dc103651-dd9e-4170-84a6-442fd27e9f94) |
| ![Screenshot 2023-05-22 at 12 00 27](https://github.com/alphagov/public-asset-checker/assets/44037625/44f4f627-a53f-4a09-9257-04fc6d4d9a8d) | ![Screenshot 2023-05-22 at 11 59 06](https://github.com/alphagov/public-asset-checker/assets/44037625/6261d1e2-e73e-4864-a40f-fd4cda736f6d) |



[Trello](https://trello.com/c/TCDeT6v8/518-updates-to-public-asset-checker)