### PR TITLE
Add rake runner button and controller action

### DIFF
--- a/app/controllers/public_assets_controller.rb
+++ b/app/controllers/public_assets_controller.rb
@@ -50,6 +50,13 @@ class PublicAssetsController < ApplicationController
     redirect_to public_assets_url, notice: "Public asset was successfully destroyed."
   end
 
+  def rake_runner
+    run_rake("public_assets:check_all_sizes")
+    run_rake("public_assets:check_all_versions")
+
+    redirect_to public_assets_url, notice: "Rake tasks run."
+  end
+
 private
 
   def set_public_asset
@@ -58,5 +65,13 @@ private
 
   def public_asset_params
     params.require(:public_asset).permit(:url, :validate_by)
+  end
+
+  def run_rake(task)
+    log_file = File.join(Rails.root, "log/#{Rails.env}.log")
+
+    Process.fork {
+      exec("bin/rake #{task} --trace 2>&1 >> #{log_file}")
+    }
   end
 end

--- a/app/views/public_assets/index.html.erb
+++ b/app/views/public_assets/index.html.erb
@@ -42,3 +42,5 @@
     </tbody>
   </table>
 </p>
+
+<%= link_to "Run checker tasks", rake_runner_path, class: "govuk-button", data: { module: "govuk-button" } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   resources :public_assets
   post "/public_asset_statuses", to: "public_asset_statuses#create"
+  get "/rake_runner", to: "public_assets#rake_runner"
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response
 


### PR DESCRIPTION
It would be nice - instead of having to wait for the daily checker rake tasks to be run - to run these on-purpose via the UI.

This change adds the ability to do that. Note: we background the tasks, so on Heroku we may need a `worker` dyno for this to work.