### PR TITLE
Add regex configuration for source and hosted file versions

### DIFF
--- a/app/controllers/public_asset_statuses_controller.rb
+++ b/app/controllers/public_asset_statuses_controller.rb
@@ -12,6 +12,6 @@ class PublicAssetStatusesController < ApplicationController
 private
 
   def public_asset_status_params
-    params.require(:public_asset_status).permit(:public_asset_id, :size, :version)
+    params.require(:public_asset_status).permit(:public_asset_id, :value)
   end
 end

--- a/app/controllers/public_assets_controller.rb
+++ b/app/controllers/public_assets_controller.rb
@@ -62,10 +62,10 @@ private
   end
 
   def run_rake(task)
-    log_file = File.join(Rails.root, "log/#{Rails.env}.log")
+    log_file = Rails.root.join("log/#{Rails.env}.log")
 
-    Process.fork {
+    Process.fork do
       exec("bin/rake #{task} --trace 2>&1 >> #{log_file}")
-    }
+    end
   end
 end

--- a/app/controllers/public_assets_controller.rb
+++ b/app/controllers/public_assets_controller.rb
@@ -11,13 +11,7 @@ class PublicAssetsController < ApplicationController
 
     dates = statuses.map(&:created_at)
     @labels = dates.map { |date| Date.parse(date.to_s).strftime("%d/%m/%Y") }
-
-    if @public_asset.validate_by_size?
-      @values = statuses.map(&:size)
-    elsif @public_asset.validate_by_version?
-      versions = statuses.map(&:version)
-      @values = versions.map { |version| version.split("=").last.gsub('"', "").to_i }
-    end
+    @values = statuses.map(&:value)
   end
 
   def new
@@ -64,7 +58,7 @@ private
   end
 
   def public_asset_params
-    params.require(:public_asset).permit(:url, :validate_by)
+    params.require(:public_asset).permit(:url, :validate_by, :hosted_version_regex, :source_version_regex)
   end
 
   def run_rake(task)

--- a/app/models/asset_size_checker.rb
+++ b/app/models/asset_size_checker.rb
@@ -13,13 +13,13 @@ class AssetSizeChecker
   def compare
     response = Faraday.get(asset.url)
     current = response.body.bytesize
-    expected = asset.latest_size
+    expected = asset.latest_value
 
     notification = Notification.new(asset.id, asset.url)
     if expected == current
       nothing_to_do(notification, humanize_size(current), humanize_size(expected))
     elsif within_tolerance?(current, expected)
-      PublicAssetStatus.create!(public_asset_id: asset.id, size: current)
+      PublicAssetStatus.create!(public_asset_id: asset.id, value: current)
       automatic_update(notification, humanize_size(current), humanize_size(expected))
     else
       action_required(notification, humanize_size(current), humanize_size(expected))

--- a/app/models/asset_version_checker.rb
+++ b/app/models/asset_version_checker.rb
@@ -8,8 +8,8 @@ class AssetVersionChecker
   end
 
   def compare
-    current = get_version(asset.url, /T="(\d+)"/)
-    expected = get_version(ENV["GITHUB_URL"], /SCRIPT_VERSION = "(\d+)"/)
+    current = get_version(asset.url, asset.hosted_version_regex)
+    expected = get_version(ENV["GITHUB_URL"], asset.source_version_regex)
 
     notification = Notification.new(asset.id, asset.url)
     if expected == current
@@ -22,7 +22,7 @@ class AssetVersionChecker
   def get_version(url, regex)
     response = Faraday.get(url)
     match_data = response.body.match(regex)
-    match_data ? match_data.captures.first : nil
+    match_data ? match_data.captures.first.to_i : nil
   end
 
 private

--- a/app/models/public_asset.rb
+++ b/app/models/public_asset.rb
@@ -12,8 +12,8 @@ class PublicAsset < ApplicationRecord
     validate_by == "version"
   end
 
-  def latest_size
-    public_asset_statuses.order(created_at: :desc).first.size
+  def latest_value
+    public_asset_statuses.order(created_at: :desc).first.value
   end
 
   def self.sizes

--- a/app/models/public_asset_status.rb
+++ b/app/models/public_asset_status.rb
@@ -2,10 +2,5 @@ class PublicAssetStatus < ApplicationRecord
   belongs_to :public_asset
 
   validates :public_asset_id, presence: true
-  validates :size, presence: true, unless: :version
-  validates :version, presence: true, unless: :size
-
-  def value
-    version || size
-  end
+  validates :value, presence: true
 end

--- a/app/views/public_asset_statuses/_form.html.erb
+++ b/app/views/public_asset_statuses/_form.html.erb
@@ -4,18 +4,17 @@
   <% current_value = @public_asset.public_asset_statuses.last.value if @public_asset.public_asset_statuses.any? %>
 
   <% if @public_asset.validate_by_version? %>
-
-    <div class="govuk-form-group">
-      <%= form.text_field :version, value: current_value, class: "govuk-input" %>
-    </div>
+    <% hint = "Please give new version number." %>
   <% else %>
-    <div class="govuk-form-group">
-      <div id="size-hint" class="govuk-hint">
-        Please give new size in Bytes without commas.
-      </div>
-      <%= form.number_field :size, value: current_value, class: "govuk-input" %>
-    </div>
+    <% hint = "Please give new size in Bytes without commas." %>
   <% end %>
+
+  <div class="govuk-form-group">
+    <div id="size-hint" class="govuk-hint">
+      <%= hint %>
+    </div>
+    <%= form.number_field :value, value: current_value, class: "govuk-input" %>
+  </div>
 
   <%= form.submit "Update", class: "govuk-button" %>
 <% end %>

--- a/app/views/public_assets/_form.html.erb
+++ b/app/views/public_assets/_form.html.erb
@@ -41,5 +41,23 @@
     <%= form.select :validate_by, ["size", "version"], { selected: @public_asset.validate_by }, { class: "govuk-select" } %>
   </div>
 
+  <% if @public_asset.validate_by_version? %>
+    <div class="govuk-form-group">
+      <%= form.label :hosted_version_regex, class: "govuk-label govuk-label--m" %>
+      <div id="size-hint" class="govuk-hint">
+        Please enter a regex which has a capture group for the version number of the GOV.UK maintained JavaScript file.
+      </div>
+      <%= form.text_field :hosted_version_regex, value: @public_asset.hosted_version_regex, class: "govuk-input" %>
+    </div>
+
+    <div class="govuk-form-group">
+      <%= form.label :source_version_regex, class: "govuk-label govuk-label--m" %>
+      <div id="size-hint" class="govuk-hint">
+        Please enter a regex which has a capture group for the version number of the source JavaScript file as it appears on <a href="<%= ENV['GITHUB_URL'] %>" target="_blank">GitHub</a>.
+      </div>
+      <%= form.text_field :source_version_regex, value: @public_asset.source_version_regex, class: "govuk-input" %>
+    </div>
+  <% end %>
+
   <%= form.submit "Save", class: "govuk-button" %>
 <% end %>

--- a/db/migrate/20230525091153_add_regex_config_to_public_asset.rb
+++ b/db/migrate/20230525091153_add_regex_config_to_public_asset.rb
@@ -1,0 +1,7 @@
+class AddRegexConfigToPublicAsset < ActiveRecord::Migration[7.0]
+  def change
+    change_table :public_assets do |t|
+      t.string :hosted_version_regex, :source_version_regex
+    end
+  end
+end

--- a/db/migrate/20230525101210_update_version_and_size_on_public_asset_statuses.rb
+++ b/db/migrate/20230525101210_update_version_and_size_on_public_asset_statuses.rb
@@ -1,0 +1,8 @@
+class UpdateVersionAndSizeOnPublicAssetStatuses < ActiveRecord::Migration[7.0]
+  def change
+    change_table :public_asset_statuses do |t|
+      t.remove :version, type: :string
+      t.rename :size, :value
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_17_132540) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_25_101210) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "public_asset_statuses", force: :cascade do |t|
     t.integer "public_asset_id"
-    t.integer "size"
-    t.string "version"
+    t.integer "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -27,6 +26,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_17_132540) do
     t.string "validate_by"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "hosted_version_regex"
+    t.string "source_version_regex"
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,6 +11,8 @@ PublicAsset.create!(
     {
       url: "https://cdn.speedcurve.com/js/lux.js?id=47044334",
       validate_by: "version",
+      hosted_version_regex: 'H="(\d+)"',
+      source_version_regex: 'SCRIPT_VERSION = "(\d+)"',
     },
   ],
 )
@@ -21,23 +23,11 @@ if Rails.env.development?
   to_date_time = Time.zone.today
   from_date_time = to_date_time - 30
 
-  public_assets_by_size = PublicAsset.where(validate_by: "size")
-  public_assets_by_version = PublicAsset.where(validate_by: "version")
-
   (from_date_time..to_date_time).each do |date_time|
-    public_assets_by_size.all.each do |asset|
+    PublicAsset.all.each do |asset|
       PublicAssetStatus.create!(
         public_asset_id: asset.id,
-        size: Faker::Number.number(digits: 6),
-        created_at: date_time,
-        updated_at: date_time,
-      )
-    end
-
-    public_assets_by_version.all.each do |asset|
-      PublicAssetStatus.create!(
-        public_asset_id: asset.id,
-        version: "T=\"#{Faker::Number.number(digits: 3)}\"",
+        value: Faker::Number.number(digits: 4),
         created_at: date_time,
         updated_at: date_time,
       )

--- a/spec/factories/public_asset_statuses.rb
+++ b/spec/factories/public_asset_statuses.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :public_asset_status do
     public_asset
-    size { 10 }
+    value { 10 }
   end
 end

--- a/spec/models/asset_size_checker_spec.rb
+++ b/spec/models/asset_size_checker_spec.rb
@@ -24,8 +24,7 @@ RSpec.describe AssetSizeChecker, type: :model do
     let(:asset_status) do
       create :public_asset_status,
              public_asset: asset,
-             size: 10,
-             version: nil
+             value: 10
     end
 
     it "when the response value is not the same and is within the tolerance we update the record" do

--- a/spec/models/asset_version_checker_spec.rb
+++ b/spec/models/asset_version_checker_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe AssetVersionChecker, type: :model do
 
       version = checker.get_version(asset.url, /T="(\d+)"/)
 
-      expect(version).to eq("42")
+      expect(version).to eq(42)
     end
 
     it "does not find the version number when it is not present in the file" do
@@ -23,13 +23,17 @@ RSpec.describe AssetVersionChecker, type: :model do
   end
 
   describe "compare" do
-    let(:asset) { create(:public_asset, validate_by: "version") }
+    let(:asset) do
+      create :public_asset,
+             validate_by: "version",
+             hosted_version_regex: 'T="(\d+)"',
+             source_version_regex: 'SCRIPT_VERSION = "(\d+)"'
+    end
     let(:checker) { described_class.new(asset) }
     let(:asset_status) do
       create :public_asset_status,
              public_asset:,
-             size: nil,
-             version: 42
+             value: 42
     end
 
     it "when the versions match, we get a Nothing to do notification" do

--- a/spec/models/public_asset_spec.rb
+++ b/spec/models/public_asset_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe PublicAsset, type: :model do
   describe "#latest_size" do
     it "returns the latest size" do
       public_asset = create(:public_asset, url: "https://www.asos.com", validate_by: "version")
-      create(:public_asset_status, size: 1824, public_asset:, updated_at: Time.zone.now - 1, created_at: Time.zone.now - 1)
-      create(:public_asset_status, size: 999, public_asset:, updated_at: Time.zone.now, created_at: Time.zone.now)
-      expect(public_asset.latest_size).to eq 999
+      create(:public_asset_status, value: 1824, public_asset:, updated_at: Time.zone.now - 1, created_at: Time.zone.now - 1)
+      create(:public_asset_status, value: 999, public_asset:, updated_at: Time.zone.now, created_at: Time.zone.now)
+      expect(public_asset.latest_value).to eq 999
     end
   end
 

--- a/spec/models/public_asset_status_spec.rb
+++ b/spec/models/public_asset_status_spec.rb
@@ -1,14 +1,13 @@
 RSpec.describe PublicAssetStatus, type: :model do
   it { is_expected.to validate_presence_of :public_asset_id }
-  it { is_expected.to validate_presence_of :size }
-  it { is_expected.to validate_presence_of :version }
+  it { is_expected.to validate_presence_of :value }
 
   describe "#value" do
-    let(:public_asset_status_size) { described_class.new(size: 123) }
-    let(:public_asset_status_version) { described_class.new(version: 'T="123"') }
+    let(:public_asset_status_size) { described_class.new(value: 123) }
+    let(:public_asset_status_version) { described_class.new(value: 123) }
 
     it "returns the version" do
-      expect(public_asset_status_version.value).to eq 'T="123"'
+      expect(public_asset_status_version.value).to eq 123
     end
 
     it "returns the size" do

--- a/spec/requests/public_asset_statuses_spec.rb
+++ b/spec/requests/public_asset_statuses_spec.rb
@@ -15,16 +15,14 @@ RSpec.describe "/public_asset_statuses", type: :request do
   let(:valid_attributes) do
     {
       public_asset_id: public_asset.id,
-      size: 123,
-      version: "",
+      value: 123,
     }
   end
 
   let(:invalid_attributes) do
     {
       public_asset_id: public_asset.id,
-      size: nil,
-      version: nil,
+      value: nil,
     }
   end
 

--- a/spec/requests/public_assets_spec.rb
+++ b/spec/requests/public_assets_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe "/public_assets", type: :request do
     {
       url: "https://www.bedrock.com/",
       validate_by: "size",
+      hosted_version_regex: 'T="(\d+)"',
+      source_version_regex: 'SCRIPT_VERSION = "(\d+)"',
     }
   end
 
@@ -102,6 +104,8 @@ RSpec.describe "/public_assets", type: :request do
         public_asset.reload
         expect(public_asset.url).to eq("https://www.slate.com")
         expect(public_asset.validate_by).to eq("version")
+        expect(public_asset.hosted_version_regex).to eq('T="(\d+)"')
+        expect(public_asset.source_version_regex).to eq('SCRIPT_VERSION = "(\d+)"')
       end
 
       it "redirects to the public_asset" do


### PR DESCRIPTION
When the current LUX source JavaScript file changes and a new version is created for our GOV.UK hosted version of that file, the way the version is specified subtly changes. For example, it recently went from `T="307"` to `H="308"`.

Controlling these changes would likely require changes in the source LUX script by the owners. Something, that for our use here, seems like a really big ask with a strong likelihood of refusal. So, we need a way to mitigate these changes within the system.

The simplest solution seems to be to add the ability to add and update the required regex's on the UI - one regex for the hosted script, and one for the source script. 

Once that has happened, we then need to merge `size` and `version` into a single `value` field. This is because the `version` field we were using is no longer storing the regex, but just the version - so we can simplify things.

| Before | After |
|---|---|
| ![Screenshot 2023-05-25 at 16 20 35](https://github.com/alphagov/public-asset-checker/assets/44037625/55624a6f-a7b3-42a4-bc0f-9a5a6b4594b4) | ![Screenshot 2023-05-25 at 16 19 16](https://github.com/alphagov/public-asset-checker/assets/44037625/6a2ed324-d3bc-4b4c-b0f2-29b920fc8933) | 

### How to review

If you want/need to get the application up-and-running locally, the simplest way is to reset the database and seed it again. To do that...

```bash
rake db:drop db:create db:migrate db:seed
```
Or just

```
rails db:reset
```
