### PR TITLE
Fix ours and theirs mixup on version

### DIFF
--- a/app/models/asset_version_checker.rb
+++ b/app/models/asset_version_checker.rb
@@ -8,8 +8,8 @@ class AssetVersionChecker
   end
 
   def compare
-    current = get_version(asset.url, asset.hosted_version_regex)
-    expected = get_version(ENV["GITHUB_URL"], asset.source_version_regex)
+    current = get_version(ENV["GITHUB_URL"], asset.source_version_regex)
+    expected = get_version(asset.url, asset.hosted_version_regex)
 
     notification = Notification.new(asset.id, asset.url)
     if expected == current
@@ -30,7 +30,7 @@ private
   def action_required(notification, current, expected)
     notification.title = "Action required"
     notification.color = "needs-attention"
-    notification.value = "<#{ENV['GITHUB_URL']}|Source version> is *#{expected}* <#{notification.url}|Our version> is *#{current}*. Please fix our version then update the <#{ENV['PRODUCTION_URL']}/public_assets/#{notification.id}|latest value>."
+    notification.value = "<#{notification.url}|Source version> is *#{expected}* <#{ENV['GITHUB_URL']}|Our version> is *#{current}*. Please fix our version then update the <#{ENV['PRODUCTION_URL']}/public_assets/#{notification.id}|latest value>."
 
     notification
   end
@@ -38,7 +38,7 @@ private
   def nothing_to_do(notification, current, expected)
     notification.title = "Nothing to do"
     notification.color = "same"
-    notification.value = "<#{ENV['GITHUB_URL']}|Source version> is *#{expected}* <#{notification.url}|Our version> is *#{current}*."
+    notification.value = "<#{notification.url}|Source version> is *#{expected}* <#{ENV['GITHUB_URL']}|Our version> is *#{current}*."
 
     notification
   end

--- a/app/views/public_assets/index.html.erb
+++ b/app/views/public_assets/index.html.erb
@@ -32,9 +32,11 @@
           </td>
           <td scope="row" class="govuk-table__cell">
             <%= link_to "Show", public_asset, class: "govuk-link" %>
-            | <%= link_to "Open", public_asset.url, target: :_blank, class: "govuk-link" %>
             <% if public_asset.validate_by_version? %>
-              | <%= link_to "Source", ENV["GITHUB_URL"], target: :_blank, class: "govuk-link" %>
+              | <%= link_to "Ours", ENV["GITHUB_URL"], target: :_blank, class: "govuk-link" %>
+              | <%= link_to "Source", public_asset.url, target: :_blank, class: "govuk-link" %>
+            <% else %>
+              | <%= link_to "Open", public_asset.url, target: :_blank, class:  "govuk-link" %>
             <% end %>
           </td>
         </tr>

--- a/app/views/public_assets/show.html.erb
+++ b/app/views/public_assets/show.html.erb
@@ -10,9 +10,11 @@
 <p class="govuk-body">
   <%= link_to "Edit", edit_public_asset_path(@public_asset), class: "govuk-link" %>
   | <%= link_to "New", new_public_asset_path, class: "govuk-link" %>
-  | <%= link_to "Open", @public_asset.url, target: :_blank, class: "govuk-link" %>
   <% if @public_asset.validate_by_version? %>
-    | <%= link_to "Source", ENV["GITHUB_URL"], target: :_blank, class: "govuk-link" %>
+    | <%= link_to "Ours", ENV["GITHUB_URL"], target: :_blank, class: "govuk-link" %>
+    | <%= link_to "Source", @public_asset.url, target: :_blank, class: "govuk-link" %>
+  <% else %>
+    | <%= link_to "Open", @public_asset.url, target: :_blank, class: "govuk-link" %>
   <% end %>
   <br/>
 


### PR DESCRIPTION
Turns out that the `ours` `theirs` wording on version-based checks is the wrong way around 😁 

This change fixes that issue.