### PR TITLE
Make rubocop and rspec pass

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -577,6 +577,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
   x86_64-darwin-21
   x86_64-linux
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,7 +24,7 @@ if Rails.env.development?
   from_date_time = to_date_time - 30
 
   (from_date_time..to_date_time).each do |date_time|
-    PublicAsset.all.each do |asset|
+    PublicAsset.find_each do |asset|
       PublicAssetStatus.create!(
         public_asset_id: asset.id,
         value: Faker::Number.number(digits: 4),

--- a/spec/requests/public_assets_spec.rb
+++ b/spec/requests/public_assets_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "/public_assets", type: :request do
 
       it "renders a response with 422 status (i.e. to display the 'new' template)" do
         post(public_assets_url, params: { public_asset: invalid_attributes }, headers:)
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(422) # rubocop:disable RSpecRails/HttpStatus
       end
     end
   end
@@ -120,7 +120,7 @@ RSpec.describe "/public_assets", type: :request do
       it "renders a response with 422 status (i.e. to display the 'edit' template)" do
         public_asset = PublicAsset.create! valid_attributes
         patch(public_asset_url(public_asset), params: { public_asset: { url: "", validate_by: "version" } }, headers:)
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(422) # rubocop:disable RSpecRails/HttpStatus
       end
     end
   end


### PR DESCRIPTION
## What

Apply a fix suggested by Rubocop and disable some Rubocop checks on some lines. Those checks can be reenabled after gems are upgraded, as their old versions do not support using symbols as HTTP status codes.

## Why

So rubocop and rspec tests pass in order to start upgrading the dependencies and have things covered by tests.