### PR TITLE
Revert "Temporarily disable certain rubocop checks"

### DIFF
--- a/spec/requests/public_assets_spec.rb
+++ b/spec/requests/public_assets_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "/public_assets", type: :request do
 
       it "renders a response with 422 status (i.e. to display the 'new' template)" do
         post(public_assets_url, params: { public_asset: invalid_attributes }, headers:)
-        expect(response).to have_http_status(422) # rubocop:disable RSpecRails/HttpStatus
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end
@@ -120,7 +120,7 @@ RSpec.describe "/public_assets", type: :request do
       it "renders a response with 422 status (i.e. to display the 'edit' template)" do
         public_asset = PublicAsset.create! valid_attributes
         patch(public_asset_url(public_asset), params: { public_asset: { url: "", validate_by: "version" } }, headers:)
-        expect(response).to have_http_status(422) # rubocop:disable RSpecRails/HttpStatus
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end


### PR DESCRIPTION
## What

This reverts commit 1cc47822ebf842c63acae154b617f36fcbf674b2, which disabled certain rubocop checks for some lines of code. This was explained [in this PR](https://github.com/alphagov/public-asset-checker/pull/126)

## Why

Disabling those checks was temporary, so the tests are green when performing gem updates. After gems related to testing got updated it is no longer necessary to disable those checks.

