### PR TITLE
Add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,15 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
+      exclude:
+        - govuk_*
+        - rubocop-govuk  
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3    


### PR DESCRIPTION
To add cooldown period for 
- bundler (3 days) with exclusion for alphagov gems that have their own cooldown
-  npm (3 days) 

Ref. https://docs.publishing.service.gov.uk/manual/manage-dependencies.html#example-configurations

[JIRA ticket](https://gov-uk.atlassian.net/browse/PNP-10048)